### PR TITLE
Adds option of 4-dim uint8 tensor input (in addition to Dataset)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -11,3 +11,10 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
+MODIFICATIONS:
+
+Copyright 2021 Vikram Voleti
+
+Apr 1, 2021
+- (feature_extractor_inceptionv3.py, utils.py) Added support for single 4-dim uint8 tensor as input (in addition to string or Dataset)

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ makes overall training time just one hour longer.
 ```python
 from torch_fidelity import calculate_metrics
 
-# Each input can be either a string (path to images, registered input), or a Dataset instance
+# Each input can be either a string (path to images, registered input), or a Dataset instance, or uint8 tensor of images [N,C,H,W]
 metrics_dict = calculate_metrics(input1, input2, cuda=True, isc=True, fid=True, kid=True, verbose=False)
 
 print(metrics_dict)
@@ -137,7 +137,7 @@ into the feature extractor (refer to `Cifar10_RGB` for example),
 
 #### Working with Files
 
-If a positional argument is not a Dataset instance or a registered input, it is treated as a directory with images (jpg, png). 
+If a positional argument is not a Dataset instance or a registered input or a 4D uint8 tensor, it is treated as a directory with images (jpg, png). 
 To collect files recursively under the provided path, add `--samples-find-deep` command line key, or set 
 the `samples_find_deep` keyword argument to True. 
 To change file extensions picked up when traversing the path, specify `--samples-find-ext` command line key or 

--- a/torch_fidelity/feature_extractor_inceptionv3.py
+++ b/torch_fidelity/feature_extractor_inceptionv3.py
@@ -74,7 +74,7 @@ class FeatureExtractorInceptionV3(FeatureExtractorBase):
             p.requires_grad_(False)
 
     def forward(self, x):
-        vassert(torch.is_tensor(x) and x.dtype == torch.uint8, 'Expecting image as torch.Tensor with dtype=torch.uint8')
+        vassert(torch.is_tensor(x) and x.dtype == torch.uint8, f'Expecting image as torch.Tensor with dtype=torch.uint8, got {type(x)}')
         features = {}
         remaining_features = self.features_list.copy()
 

--- a/torch_fidelity/utils.py
+++ b/torch_fidelity/utils.py
@@ -56,7 +56,8 @@ def create_feature_extractor(name, list_features, cuda=True, **kwargs):
 
 
 def get_featuresdict_from_dataset(input, feat_extractor, batch_size, cuda, save_cpu_ram, verbose):
-    vassert(isinstance(input, Dataset), 'Input can only be a Dataset instance')
+    vassert(isinstance(input, Dataset) or (torch.is_tensor(input) and (input.dtype == torch.uint8) and input.ndim == 4),
+        'Input can only be a Dataset instance, or a 4-D tensor of type torch.uint8')
     vassert(
         isinstance(feat_extractor, FeatureExtractorBase), 'Feature extractor is not a subclass of FeatureExtractorBase'
     )
@@ -100,10 +101,18 @@ def get_featuresdict_from_dataset(input, feat_extractor, batch_size, cuda, save_
 
 
 def check_input(input):
-    vassert(
-        type(input) is str or isinstance(input, Dataset),
-        f'Input can be either a Dataset instance, or a string (path to directory with samples, or one of the '
-        f'registered datasets: {", ".join(DATASETS_REGISTRY.keys())}'
+    check = type(input) is str or isinstance(input, Dataset) or \
+            (torch.is_tensor(input) and (input.dtype == torch.uint8) and input.ndim == 4)
+    err = ''
+    if not check and torch.is_tensor(input):
+        if input.dtype != torch.uint8:
+            err = f' dtype of tensor is not uint8! Given {input.dtype}'
+        elif input.ndim != 4:
+            err = f' input must have 4 dims (stack of images)! Given: {input.ndim} dims'
+    vassert(check,
+        f'Input can be either a Dataset instance; '
+        f'or a uint8 torch.tensor of 4 dims [N,C,H,W]; or a string (path to directory with samples); '
+        f'or one of the registered datasets: {", ".join(DATASETS_REGISTRY.keys())};' + err
     )
 
 


### PR DESCRIPTION
Adds option of 4-dim uint8 tensor input (in addition to Dataset).
No specific change to code, DataLoader is already compatible with a Tensor input as well as Dataset.
Only changes are related to checking the input.

This is useful for cases when an NxCxHxW tensor is generated (from a GAN, say). This can now be directly provided to `calculate_metrics` instead of wrapping around a Dataset.