### PR TITLE
Allows for disabling feature caching but retaining statistics caching

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -11,3 +11,10 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
+MODIFICATIONS:
+
+Copyright 2021 Vikram Voleti
+
+Apr 1, 2021
+- (multiple files) Added `cache_features` arg, to not store features in cache when False (but store statistics)

--- a/torch_fidelity/defaults.py
+++ b/torch_fidelity/defaults.py
@@ -23,6 +23,7 @@ DEFAULTS = {
     'datasets_download': True,
     'cache_root': None,
     'cache': True,
+    'cache_features': True,
     'cache_input1_name': None,
     'cache_input2_name': None,
     'rng_seed': 2020,

--- a/torch_fidelity/fidelity.py
+++ b/torch_fidelity/fidelity.py
@@ -70,6 +70,8 @@ def main():
                         help='Path to file cache for features and statistics. Defaults to $ENV_TORCH_HOME/fidelity_cache')
     parser.add_argument('--no-cache', action='store_true',
                         help='Do not use file cache for features and statistics')
+    parser.add_argument('--no-cache-feaures', action='store_true',
+                        help='Do not use file cache for features (but use for statistics)')
     parser.add_argument('--cache-input1-name', default=DEFAULTS['cache_input1_name'], type=str,
                         help='Assigns a cache entry to input1 (if a path) and forces caching of features on it')
     parser.add_argument('--cache-input2-name', default=DEFAULTS['cache_input2_name'], type=str,
@@ -89,6 +91,7 @@ def main():
     args.datasets_download = not args.datasets_downloaded
     args.samples_shuffle = not args.samples_alphanumeric
     args.cache = not args.no_cache
+    args.cache_features = not args.no_cache_features
 
     if args.gpu is not None:
         os.environ['CUDA_VISIBLE_DEVICES'] = args.gpu

--- a/torch_fidelity/metrics.py
+++ b/torch_fidelity/metrics.py
@@ -66,6 +66,8 @@ def calculate_metrics(input_1, input_2=None, **kwargs):
             Path to file cache for features and statistics. Defaults to $ENV_TORCH_HOME/fidelity_cache.
         cache: bool (default: True)
             Use file cache for features and statistics.
+        cache_features: bool (default: True)
+            Use file cache for features specifically. If False, will disable caching of features, but retain caching of statistics.
         cache_input1_name: str (default: None)
             Assigns a cache entry to input1 (if a path) and forces caching of features on it if not None.
         cache_input2_name: str (default: None)

--- a/torch_fidelity/utils.py
+++ b/torch_fidelity/utils.py
@@ -210,12 +210,15 @@ def extract_featuresdict_from_input_cached(input, cacheable_input_name, feat_ext
     if cacheable_input_name is not None:
         feat_extractor_name = feat_extractor.get_name()
         cached_filename_prefix = f'{cacheable_input_name}-{feat_extractor_name}-features-'
-        featuresdict = cache_lookup_group_recompute_all_on_any_miss(
-            cached_filename_prefix,
-            feat_extractor.get_requested_features_list(),
-            fn_recompute,
-            **kwargs,
-        )
+        if not get_kwarg('cache_features', kwargs):
+            featuresdict = fn_recompute()
+        else:
+            featuresdict = cache_lookup_group_recompute_all_on_any_miss(
+                cached_filename_prefix,
+                feat_extractor.get_requested_features_list(),
+                fn_recompute,
+                **kwargs,
+            )
     else:
         featuresdict = fn_recompute()
     return featuresdict


### PR DESCRIPTION
Adds `cache_features` argument. When False, will not cache features, but will cache statistics.

`cache` argument when False will not cache features or statistics. But often, for example for FID, only the statistics of the base Dataset (such as CIFAR10) are important, not the features. Making `cache_features=False` only caches the statistics, but doesn't cache the features.