### PR TITLE
Adds support for Dataset that returns multiple items, such as (images, target)

### DIFF
--- a/torch_fidelity/utils.py
+++ b/torch_fidelity/utils.py
@@ -74,10 +74,23 @@ def get_featuresdict_from_dataset(input, feat_extractor, batch_size, cuda, save_
         pin_memory=cuda,
     )
 
+    # To check content of dataloader
+    data = next(iter(dataloader))
+
+    # Standard datasets usually output (images, target) in a batch
+    # If so, extract first element, i.e. images
+    extract_first_element = True if (isinstance(data, list) or isinstance(data, tuple)) else False
+
     out = None
 
     with tqdm(disable=not verbose, leave=False, unit='samples', total=len(input), desc='Processing samples') as t:
         for bid, batch in enumerate(dataloader):
+
+            # Standard datasets usually output (images, target) in a batch
+            # Extract images
+            if extract_first_element:
+                batch = batch[0]
+
             if cuda:
                 batch = batch.cuda(non_blocking=True)
 


### PR DESCRIPTION
Currently, code can only handle Datasets that return only the image. But, most standard PyTorch datasets (such as CIFAR10) return a tuple of (images, targets). This commit adds support for such datasets that return multiple items in a batch. It first checks for the data type in a batch, and extracts the first element in the list/tuple if it is a list/tuple.