### PR TITLE
add resize option in dataloader

### DIFF
--- a/torch_fidelity/datasets.py
+++ b/torch_fidelity/datasets.py
@@ -5,8 +5,8 @@ import torch
 from PIL import Image
 from torch.utils.data import Dataset
 from torchvision.datasets import CIFAR10, STL10
-
-from torch_fidelity.helpers import vassert
+from torchvision import transforms
+from torch_fidelity.helpers import vassert, get_kwarg
 
 
 class TransformPILtoRGBTensor:
@@ -19,9 +19,9 @@ class TransformPILtoRGBTensor:
 
 
 class ImagesPathDataset(Dataset):
-    def __init__(self, files, transforms=None):
+    def __init__(self, files, transforms=None, **kwargs):
         self.files = files
-        self.transforms = TransformPILtoRGBTensor() if transforms is None else transforms
+        self.transforms = get_transforms(**kwargs) if transforms is None else transforms
 
     def __len__(self):
         return len(self.files)
@@ -68,3 +68,20 @@ class RandomlyGeneratedDataset(Dataset):
 
     def __getitem__(self, i):
         return self.imgs[i]
+
+
+def get_transforms(**kwargs):
+    size = get_kwarg('size', kwargs)
+    crop = get_kwarg('crop', kwargs)
+
+    transform = []
+
+    if size is not None:
+        transform.append(transforms.Resize((size, size)))
+    if crop is not None:
+        transform.append(transforms.CenterCrop(crop))
+    transform.append(TransformPILtoRGBTensor())
+    
+    transform = transforms.Compose(transform)
+
+    return transform

--- a/torch_fidelity/defaults.py
+++ b/torch_fidelity/defaults.py
@@ -47,4 +47,6 @@ DEFAULTS = {
     'rng_seed': 2020,
     'save_cpu_ram': False,
     'verbose': True,
+    'size': None,
+    'crop': None,
 }

--- a/torch_fidelity/utils.py
+++ b/torch_fidelity/utils.py
@@ -228,7 +228,7 @@ def prepare_input_from_descriptor(input_desc, **kwargs):
             verbose = get_kwarg('verbose', kwargs)
             input = glob_samples_paths(input, samples_find_deep, samples_find_ext, samples_ext_lossy, verbose)
             vassert(len(input) > 0, f'No samples found in {input} with samples_find_deep={samples_find_deep}')
-            input = ImagesPathDataset(input)
+            input = ImagesPathDataset(input, **kwargs)
         elif os.path.isfile(input) and input.endswith('.onnx'):
             input = GenerativeModelONNX(
                 input,


### PR DESCRIPTION
When calculating FID, the input dataset can have images of different sizes. In order to process images with batchsize > 1 we need to resize images in `ImagesPathDataset`. 

With the current implementation, we can resize the images using the following command line options
1.  `--size` - Resize the image using bilinear interpolation
2. `--crop` - Crops the image to the desired size

Default values for both of them are `None` and no resizing will be done.